### PR TITLE
Only use first lapse rate?

### DIFF
--- a/R/get-information-from-NIW-belief.R
+++ b/R/get-information-from-NIW-belief.R
@@ -104,7 +104,7 @@ get_categorization_function_from_NIW_belief = function(x, ...) {
     Ss = x$S,
     kappas = x$kappa,
     nus = x$nu,
-    lapse_rate = x$lapse_rate,
+    lapse_rate = x$lapse_rate[[1]],
     ...
   )
 }


### PR DESCRIPTION
So, from my experience, NIW beliefs have lapse rates for each row (i.e., category). `get_categorization_function_from_NIW_belief()` took the entire column, but `assert_that(between(lapse_rate, 0, 1))` in `get_categorization_function()` implicitly asserts that `lapse_rate` is of length 1.  If you can have different lapse rates for different categories, the `assert` call in `get_categorization_function()` needs to be changed, otherwise, this change should be kept.