### PR TITLE
Fix operator-precedence bug in nolabel-criterion/proportional updating

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,5 +8,5 @@
 
 ## Bug Fixes
 
- * None yet.
+ * 26/07/06, NW, Fixed operator-precedence bug that broke nolabel-criterion and nolabel-proportional updating.
 

--- a/R/update-NIW-IA.R
+++ b/R/update-NIW-IA.R
@@ -177,9 +177,7 @@ update_NIW_belief_by_sufficient_statistics_of_one_category <- function(
               noise_treatment = noise_treatment,
               lapse_treatment = lapse_treatment,
               decision_rule = gsub("nolabel-", "", method),
-              simplify = F) %>%
-            pull(response) * x_N %>%
-            as.list()
+              simplify = F) %>% pull(response) %>% { . * x_N } %>% as.list()
         } else if (method %in% c("nolabel-sampling")) {
           x_Ns <-
             get_categorization_from_NIW_ideal_adaptor(

--- a/R/update-NIW-IA.R
+++ b/R/update-NIW-IA.R
@@ -177,7 +177,7 @@ update_NIW_belief_by_sufficient_statistics_of_one_category <- function(
               noise_treatment = noise_treatment,
               lapse_treatment = lapse_treatment,
               decision_rule = gsub("nolabel-", "", method),
-              simplify = F) %>% pull(response) %>% { . * x_N } %>% as.list()
+              simplify = F) %>% { .$response * x_N } %>% as.list()
         } else if (method %in% c("nolabel-sampling")) {
           x_Ns <-
             get_categorization_from_NIW_ideal_adaptor(

--- a/tests/testthat/test-update-NIW.R
+++ b/tests/testthat/test-update-NIW.R
@@ -1,3 +1,5 @@
+context("update NIW models")
+
 test_that("incremental updating runs for all methods (1 cue)", {
   model <- example_NIW_ideal_adaptor(example = 1, verbose = FALSE)  # 1 cue: VOT
   cats  <- get_category_labels_from_model(model)

--- a/tests/testthat/test-update-NIW.R
+++ b/tests/testthat/test-update-NIW.R
@@ -1,0 +1,28 @@
+test_that("incremental updating runs for all methods (1 cue)", {
+  model <- example_NIW_ideal_adaptor(example = 1, verbose = FALSE)  # 1 cue: VOT
+  cats  <- get_category_labels_from_model(model)
+  
+  exposure <- tibble::tibble(
+    category = rep(cats, each = 2),
+    VOT      = c(10, 20, 40, 50)
+  )
+  
+  for (m in c("label-certain", "nolabel-criterion", "nolabel-sampling",
+              "nolabel-proportional", "nolabel-uniform")) {
+    expect_no_error(
+      update_NIW_ideal_adaptor_incrementally(
+        model, exposure = exposure,
+        exposure.category = "category", exposure.cues = "VOT",
+        method = m, verbose = FALSE)
+    )
+  }
+  
+  # a bad method should still error clearly
+  expect_error(
+    update_NIW_ideal_adaptor_incrementally(
+      model, exposure = exposure,
+      exposure.category = "category", exposure.cues = "VOT",
+      method = "not-a-method"),
+    regexp = "not an acceptable updating method"
+  )
+})


### PR DESCRIPTION
## Summary
Fixes an operator-precedence bug that made `method = "nolabel-criterion"` and
`method = "nolabel-proportional"` error in
`update_NIW_belief_by_sufficient_statistics_of_one_category()`.

## The bug
In the criterion/proportional branch, `x_Ns` is computed as:

    ... simplify = F) %>% pull(response) * x_N %>% as.list()

Because `%>%` binds tighter than `*`, R parses this as
`pull(response) * (x_N %>% as.list())`, i.e. a numeric vector times a *list*,
which throws `non-numeric argument to binary operator`.

Minimal reproduction:

    c(1, 0) * (1 %>% as.list())   # Error
    (c(1, 0) * 1) %>% as.list()   # intended behaviour

Only `nolabel-criterion` and `nolabel-proportional` are affected;
`label-certain`, `nolabel-sampling`, and `nolabel-uniform` use different
groupings and work fine.

## The fix
Keep the multiplication and list-wrapping on the same side of the pipe:

    ... simplify = F) %>% pull(response) %>% { . * x_N } %>% as.list()